### PR TITLE
Two new require statements

### DIFF
--- a/tweet_tag.rb
+++ b/tweet_tag.rb
@@ -12,6 +12,8 @@
 #   https://github.com/scottwb/jekyll-tweet-tag/blob/master/README.md
 #
 require 'json'
+require 'net/http'
+require 'digest/md5'
 
 module Jekyll
   class TweetTag < Liquid::Tag


### PR DESCRIPTION
In order to get this plugin working I had to add two require statements. I think it's because I'm on Ruby 1.9.2 or maybe because I'm not using Octopress. These should work with 1.8 too, but I haven't tested it.
