### PR TITLE
Fix broken output of API errors

### DIFF
--- a/tweet_tag.rb
+++ b/tweet_tag.rb
@@ -12,7 +12,6 @@
 #   https://github.com/scottwb/jekyll-tweet-tag/blob/master/README.md
 #
 require 'json'
-require 'pry'
 
 module Jekyll
   class TweetTag < Liquid::Tag

--- a/tweet_tag.rb
+++ b/tweet_tag.rb
@@ -12,6 +12,7 @@
 #   https://github.com/scottwb/jekyll-tweet-tag/blob/master/README.md
 #
 require 'json'
+require 'pry'
 
 module Jekyll
   class TweetTag < Liquid::Tag
@@ -46,7 +47,7 @@ module Jekyll
     def html_output_for(api_params)
       body = "Tweet could not be processed"
       if response = cached_response(api_params) || live_response(api_params)
-        body = response['html'] || response['error'] || body
+        body = response['html'] || output_errors(response['errors']) || body
       end
       "<div class='embed tweet'>#{body}</div>"
     end
@@ -88,6 +89,16 @@ module Jekyll
       super
       @cache_disabled = true
     end
+  end
+
+  private
+
+  # Returns a string containing one or many errors formatted as:
+  #   Error #00: Uh Oh <br>
+  #   Error #01: Run!
+  #
+  def output_errors(errors)
+    errors.map { |error| "Error ##{error['code']}: #{error['message']} <br>"}
   end
 end
 

--- a/tweet_tag.rb
+++ b/tweet_tag.rb
@@ -94,7 +94,9 @@ module Jekyll
     #   Error #01: Run!
     #
     def output_errors(errors)
-      errors.map { |error| "Error ##{error['code']}: #{error['message']} <br>"}
+      errors.map do |error| 
+        "Error ##{error['code']}: #{error['message']}"
+      end.join('<br>')
     end
   end
 

--- a/tweet_tag.rb
+++ b/tweet_tag.rb
@@ -17,7 +17,7 @@ require 'pry'
 module Jekyll
   class TweetTag < Liquid::Tag
 
-    TWITTER_OEMBED_URL = "https://api.twitter.com/1/statuses/oembed.json"
+    TWITTER_OEMBED_URL = "http://api.twitter.com/1/statuses/oembed.json"
 
     def initialize(tag_name, text, tokens)
       super
@@ -82,6 +82,20 @@ module Jekyll
       cache(api_params, response) unless @cache_disabled
       JSON.parse(response)
     end
+
+    private
+
+    # Private: Duplicate some text an arbitrary number of times.
+    #
+    # errors  - The errors Hash fro the API response
+    #
+    # Returns a string containing one or many errors formatted as:
+    #   Error #00: Uh Oh <br>
+    #   Error #01: Run!
+    #
+    def output_errors(errors)
+      errors.map { |error| "Error ##{error['code']}: #{error['message']} <br>"}
+    end
   end
 
   class TweetTagNoCache < TweetTag
@@ -89,16 +103,6 @@ module Jekyll
       super
       @cache_disabled = true
     end
-  end
-
-  private
-
-  # Returns a string containing one or many errors formatted as:
-  #   Error #00: Uh Oh <br>
-  #   Error #01: Run!
-  #
-  def output_errors(errors)
-    errors.map { |error| "Error ##{error['code']}: #{error['message']} <br>"}
   end
 end
 


### PR DESCRIPTION
Errors are now returned in `response['errors']` instead of `response['error']` and in case
there is more than one, I just make sur to quickly output a string with all of them.
